### PR TITLE
Switch to MariaDB 10.5 from MySQL

### DIFF
--- a/src/main/docker/mysql.yml
+++ b/src/main/docker/mysql.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   ihiwmanagement-mysql:
-    image: mysql:8.0.16
+    image: mariadb:10.5
     # volumes:
     #     - ~/volumes/jhipster/ihiwManagement/mysql/:/var/lib/mysql/
     environment:


### PR DESCRIPTION
MySQL was producing SQL error when running in Docker.
  
- Fixes sql error produced by MySQL

MySQL was producing this error:
```
Still getting:
Caused by: liquibase.exception.DatabaseException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'row)' at line 1 [Failed SQL: UPDATE project_lab SET id = (SELECT @row:=@row+1 AS row)]
	at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:356)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:57)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:125)
	at liquibase.database.AbstractJdbcDatabase.execute(AbstractJdbcDatabase.java:1229)
	at liquibase.database.AbstractJdbcDatabase.executeStatements(AbstractJdbcDatabase.java:1211)
	at liquibase.changelog.ChangeSet.execute(ChangeSet.java:600)
	... 117 common frames omitted
Caused by: java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'row)' at line 1
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:120)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
	at com.mysql.cj.jdbc.StatementImpl.executeInternal(StatementImpl.java:782)
	at com.mysql.cj.jdbc.StatementImpl.execute(StatementImpl.java:666)
	at com.zaxxer.hikari.pool.ProxyStatement.execute(ProxyStatement.java:95)
	at com.zaxxer.hikari.pool.HikariProxyStatement.execute(HikariProxyStatement.java)
	at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:352)
	... 122 common frames omitted
```

for the sql:
```
        <sql>
            SET @row=0;
            UPDATE project_lab SET id = (SELECT @row:=@row+1 AS row)
        </sql>
```

in `config/liquibase/changelog/20191210160201_project_subscription_status.xml`
