### PR TITLE
#100 multiple file upload for newly created files

### DIFF
--- a/src/main/webapp/app/entities/upload/upload-update.component.html
+++ b/src/main/webapp/app/entities/upload/upload-update.component.html
@@ -33,7 +33,8 @@
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" for="field_file">File</label>
-                    <input id="field_file" type="file" (change)="onFileChange($event)"/>
+                    <input *ngIf="editForm.get('id').value === undefined" id="field_files" type="file" (change)="onFileChange($event)" multiple/>
+                    <input *ngIf="editForm.get('id').value !== undefined" id="field_file" type="file" (change)="onFileChange($event)"/>
                 </div>
             </div>
             <div>

--- a/src/main/webapp/app/entities/upload/upload-update.component.ts
+++ b/src/main/webapp/app/entities/upload/upload-update.component.ts
@@ -20,7 +20,7 @@ import { ProjectService } from 'app/entities/project';
 export class UploadUpdateComponent implements OnInit {
   isSaving: boolean;
   noFileSelected: boolean;
-  file: File;
+  files: FileList;
 
   projects: IProject[];
 
@@ -76,7 +76,7 @@ export class UploadUpdateComponent implements OnInit {
 
   onFileChange(event) {
     if (event.target.files.length > 0) {
-      this.file = event.target.files[0];
+      this.files = event.target.files;
       this.noFileSelected = false;
     }
   }
@@ -85,9 +85,13 @@ export class UploadUpdateComponent implements OnInit {
     this.isSaving = true;
     const upload = this.createFromForm();
     if (upload.id !== undefined) {
-      this.subscribeToSaveResponse(this.uploadService.update(upload, this.file));
+      let file = null;
+      if (this.files !== undefined && this.files.length > 0) {
+        file = this.files[0];
+      }
+      this.subscribeToSaveResponse(this.uploadService.update(upload, file));
     } else {
-      this.subscribeToSaveResponse(this.uploadService.createWithFile(upload, this.file));
+      this.subscribeToSaveResponse(this.uploadService.createWithFile(upload, this.files));
     }
   }
 

--- a/src/main/webapp/app/entities/upload/upload.service.ts
+++ b/src/main/webapp/app/entities/upload/upload.service.ts
@@ -25,19 +25,20 @@ export class UploadService {
       .pipe(map((res: EntityResponseType) => this.convertDateFromServer(res)));
   }
 
-  createWithFile(upload: IUpload, file: File): Observable<EntityResponseType> {
+  createWithFile(upload: IUpload, files: FileList): Observable<EntityResponseType> {
     const copy = this.convertDateFromClient(upload);
 
     const uploadMultipartFormParam = 'upload';
-    const fileMultipartFormParam = 'file';
+    const filesMultipartFormParam = 'files';
     const formData: FormData = new FormData();
     const uploadAsJsonBlob: Blob = new Blob([JSON.stringify(copy)], { type: 'application/json' });
 
     formData.append(uploadMultipartFormParam, uploadAsJsonBlob);
-    if (file !== undefined) {
-      formData.append(fileMultipartFormParam, file);
+    if (files !== undefined) {
+      for (let i = 0; i < files.length; i++) {
+        formData.append(filesMultipartFormParam, files.item(i));
+      }
     }
-
     return this.http
       .post<IUpload>(this.resourceUrl, formData, { observe: 'response' })
       .pipe(map((res: EntityResponseType) => this.convertDateFromServer(res)));


### PR DESCRIPTION
New uploads can be with multiple files (copying the same properties for all files). For each file, an individual upload object is created.

Existing uploads can only be edited with single files to avoid accidental re-upload of multiple sets of files.