### PR TITLE
allow validation user to delete an upload

### DIFF
--- a/src/main/java/org/ihiw/management/web/rest/UploadResource.java
+++ b/src/main/java/org/ihiw/management/web/rest/UploadResource.java
@@ -364,6 +364,7 @@ public class UploadResource {
         IhiwUser currentIhiwUser = ihiwUserRepository.findByUserIsCurrentUser();
 
         if (currentUser.get().getAuthorities().contains(new Authority(ADMIN)) ||
+        	currentUser.get().getAuthorities().contains(new Authority(VALIDATION)) ||
             upload.get().getCreatedBy().getLab().equals(currentIhiwUser.getLab())) {
 
         	// Delete each child of this parent upload.


### PR DESCRIPTION
This allows the user with role_validation to use the deleteUpload endpoint. Before it was usable by Admins and Lab members, but was not usable in validation. 