### PR TITLE
Feature/222

### DIFF
--- a/src/main/java/org/ihiw/management/repository/UploadRepository.java
+++ b/src/main/java/org/ihiw/management/repository/UploadRepository.java
@@ -23,10 +23,10 @@ public interface UploadRepository extends JpaRepository<Upload, Long> {
     List<Upload> findByFileName(String filename);
     
     @Query("select upload from Upload upload where upload.createdBy in ?1 and upload.parentUpload.id is null")
-    Page<Upload> findByCreatedByIn(List<IhiwUser> users, Pageable pageable);
+    Page<Upload> findParentlessByCreatedByIn(List<IhiwUser> users, Pageable pageable);
 
     @Query("select upload from Upload upload where upload.parentUpload.id is null and (upload.createdBy.id in ?1 or upload.project.id in ?2)")
-    Page<Upload> findByUsersAndProjects(List<Long> userIds, List<Long> projectIds, Pageable pageable);
+    Page<Upload> findParentlessByUsersAndProjects(List<Long> userIds, List<Long> projectIds, Pageable pageable);
 
     Optional<Upload> findById(Long id);
 
@@ -40,5 +40,5 @@ public interface UploadRepository extends JpaRepository<Upload, Long> {
     List<Upload> findChildrenById(Long id);
 
     @Query("select upload from Upload upload where upload.parentUpload.id is null")
-    Page<Upload> findAll(Pageable pageable);
+    Page<Upload> findParentless(Pageable pageable);
 }

--- a/src/main/java/org/ihiw/management/repository/UploadRepository.java
+++ b/src/main/java/org/ihiw/management/repository/UploadRepository.java
@@ -21,9 +21,11 @@ import java.util.Optional;
 public interface UploadRepository extends JpaRepository<Upload, Long> {
     List<Upload> findByCreatedByIn(List<IhiwUser> users);
     List<Upload> findByFileName(String filename);
+    
+    @Query("select upload from Upload upload where upload.createdBy.id in ?1 and upload.parentUpload is null")
     Page<Upload> findByCreatedByIn(List<IhiwUser> users, Pageable pageable);
 
-    @Query("select upload from Upload upload where upload.createdBy.id in ?1 or upload.project.id in ?2")
+    @Query("select upload from Upload upload where (upload.createdBy.id in ?1 or upload.project.id in ?2) and upload.parentUpload is null")
     Page<Upload> findByUsersAndProjects(List<Long> userIds, List<Long> projectIds, Pageable pageable);
 
     Optional<Upload> findById(Long id);
@@ -37,6 +39,6 @@ public interface UploadRepository extends JpaRepository<Upload, Long> {
     @Query("select upload from Upload upload where upload.parentUpload.id = ?1")
     List<Upload> findChildrenById(Long id);
 
-    @Query("select upload from Upload upload")
-    Page<Upload> findAllUploads(Pageable pageable);
+    @Query("select upload from Upload upload where upload.parentUpload.id is null")
+    Page<Upload> findAll(Pageable pageable);
 }

--- a/src/main/java/org/ihiw/management/repository/UploadRepository.java
+++ b/src/main/java/org/ihiw/management/repository/UploadRepository.java
@@ -22,10 +22,10 @@ public interface UploadRepository extends JpaRepository<Upload, Long> {
     List<Upload> findByCreatedByIn(List<IhiwUser> users);
     List<Upload> findByFileName(String filename);
     
-    @Query("select upload from Upload upload where upload.createdBy.id in ?1 and upload.parentUpload is null")
+    @Query("select upload from Upload upload where upload.createdBy in ?1 and upload.parentUpload.id is null")
     Page<Upload> findByCreatedByIn(List<IhiwUser> users, Pageable pageable);
 
-    @Query("select upload from Upload upload where (upload.createdBy.id in ?1 or upload.project.id in ?2) and upload.parentUpload is null")
+    @Query("select upload from Upload upload where upload.parentUpload.id is null and (upload.createdBy.id in ?1 or upload.project.id in ?2)")
     Page<Upload> findByUsersAndProjects(List<Long> userIds, List<Long> projectIds, Pageable pageable);
 
     Optional<Upload> findById(Long id);

--- a/src/main/java/org/ihiw/management/service/UserService.java
+++ b/src/main/java/org/ihiw/management/service/UserService.java
@@ -381,13 +381,13 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public Page<UploadDTO> getAllUploads(Pageable pageable) {
-        return  uploadRepository.findAll(pageable).map(UploadDTO::new);
+    public Page<UploadDTO> getParentlessUploads(Pageable pageable) {
+        return  uploadRepository.findParentless(pageable).map(UploadDTO::new);
     }
 
     @Transactional(readOnly = true)
-    public Page<UploadDTO> getAllUploadsByUserId(Pageable pageable, List<IhiwUser> users) {
-        return uploadRepository.findByCreatedByIn(users, pageable).map(UploadDTO::new);
+    public Page<UploadDTO> getParentlessUploadsByUserId(Pageable pageable, List<IhiwUser> users) {
+        return uploadRepository.findParentlessByCreatedByIn(users, pageable).map(UploadDTO::new);
     }
     
     public List<Upload> getAllUploadsByParentId(long parentId) { 	
@@ -396,18 +396,25 @@ public class UserService {
     }
     
     @Transactional(readOnly = true)
-    public Page<UploadDTO> getAllUploadsByUsersAndProjects(Pageable pageable, List<IhiwUser> users, List<Project> projects) {
-
+    public Page<UploadDTO> getParentlessUploadsByUsersAndProjects(Pageable pageable, List<IhiwUser> users, List<Project> projects) {
+    	
     	List<Long> userIds = new ArrayList<Long>();      	
         for (IhiwUser ihiwUser : users) {
         	userIds.add(ihiwUser.getId());
         }
+        
        	List<Long> projectIds = new ArrayList<Long>();
-       	projectIds.add(new Long(-1)); // Default Value, because findByUsersAndProjects crashes with an empty projectIDs list(Which is possible in some cases)
         for (Project project : projects) {
         	projectIds.add(project.getId());
         }
-        return  uploadRepository.findByUsersAndProjects(userIds, projectIds, pageable).map(UploadDTO::new);
+        
+        if(projectIds.size() < 1) {
+          	return uploadRepository.findParentlessByCreatedByIn(users, pageable).map(UploadDTO::new);	
+        }
+        else {
+        	return uploadRepository.findParentlessByUsersAndProjects(userIds, projectIds, pageable).map(UploadDTO::new);
+        }
+
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/ihiw/management/service/UserService.java
+++ b/src/main/java/org/ihiw/management/service/UserService.java
@@ -387,7 +387,12 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public Page<UploadDTO> getAllUploadsByUserId(Pageable pageable, List<IhiwUser> users) {
-        return  uploadRepository.findByCreatedByIn(users, pageable).map(UploadDTO::new);
+        return uploadRepository.findByCreatedByIn(users, pageable).map(UploadDTO::new);
+    }
+    
+    public List<Upload> getAllUploadsByParentId(long parentId) { 	
+    	List<Upload> childUploads = uploadRepository.findChildrenById(parentId);     	
+    	return childUploads;
     }
     
     @Transactional(readOnly = true)
@@ -398,6 +403,7 @@ public class UserService {
         	userIds.add(ihiwUser.getId());
         }
        	List<Long> projectIds = new ArrayList<Long>();
+       	projectIds.add(new Long(-1)); // Default Value, because findByUsersAndProjects crashes with an empty projectIDs list(Which is possible in some cases)
         for (Project project : projects) {
         	projectIds.add(project.getId());
         }

--- a/src/main/java/org/ihiw/management/web/rest/UploadResource.java
+++ b/src/main/java/org/ihiw/management/web/rest/UploadResource.java
@@ -269,17 +269,17 @@ public class UploadResource {
                 
         if (currentUser.get().getAuthorities().contains(new Authority(ADMIN))
         		|| currentUser.get().getAuthorities().contains(new Authority(VALIDATION))) {
-            page = userService.getAllUploads(pageable);
+            page = userService.getParentlessUploads(pageable);
         } else {
         	IhiwLab currentLab = currentIhiwUser.getLab();
             List<IhiwUser> colleagues = ihiwUserRepository.findByLab(currentLab);
         	
         	if (currentUser.get().getAuthorities().contains(new Authority(PROJECT_LEADER))) {            	
         	    List<Project> projects = projectRepository.findAllByLeaders(currentIhiwUser);      
-                page = userService.getAllUploadsByUsersAndProjects(pageable, colleagues, projects);       
+                page = userService.getParentlessUploadsByUsersAndProjects(pageable, colleagues, projects);       
             }
         	else {
-        		page = userService.getAllUploadsByUserId(pageable, colleagues);       
+        		page = userService.getParentlessUploadsByUserId(pageable, colleagues);       
         	}         
         }
         

--- a/src/main/java/org/ihiw/management/web/rest/UploadResource.java
+++ b/src/main/java/org/ihiw/management/web/rest/UploadResource.java
@@ -265,15 +265,17 @@ public class UploadResource {
         } else {
             pageable = Pageable.unpaged();
         }
+        
+        log.debug("Pageable object:" + pageable.toString());
 
         if (currentUser.get().getAuthorities().contains(new Authority(ADMIN))
         		|| currentUser.get().getAuthorities().contains(new Authority(VALIDATION))) {
             page = userService.getAllUploads(pageable);
         } else {
         	IhiwLab currentLab = currentIhiwUser.getLab();
-        	log.debug("Current Lab:" + currentLab.toString());
+        	//log.debug("Current Lab:" + currentLab.toString());
             List<IhiwUser> colleagues = ihiwUserRepository.findByLab(currentLab);
-        	log.debug("Colleagues Found:" + colleagues.toString());
+        	//log.debug("Colleagues Found:" + colleagues.toString());
         	
         	// Project leaders need to see uploads for their own projects.
         	if (currentUser.get().getAuthorities().contains(new Authority(PROJECT_LEADER))) {            	


### PR DESCRIPTION
Improving Paging for Feature #222 



Paging requests query only the parent uploads (parent id = Null). This paging shows 100 parent uploads per page (except the last page).  While there are different number of total uploads per page, 100 parent uploads per page visually looks reasonably consistent. Paging still uses indexes (Page 1/N) based on the list of parent uploads.

Child uploads are afterwards iterated and added to the page, inside the REST endpoint. 

This should resolve paging issues such as missing uploads that are lost between the pages, and empty pages (Because when Parents and Children are separated on different pages, the Children are NOT shown at all)

The drawback is: The total upload count shown at the bottom is only parent uploads. And technically it's inconsistent numbers per page. I think these are small problems.